### PR TITLE
added method to force user display name

### DIFF
--- a/android/src/main/java/com/applozic/ApplozicChatModule.java
+++ b/android/src/main/java/com/applozic/ApplozicChatModule.java
@@ -138,6 +138,29 @@ public class ApplozicChatModule extends ReactContextBaseJavaModule implements Ac
     }
 
     @ReactMethod
+    public void openChatWithUserName(String userId, String userName) {
+        Activity currentActivity = getCurrentActivity();
+
+        if (currentActivity == null) {
+            Log.i("open ChatWithUser  ", "Activity doesn't exist");
+            return;
+        }
+
+        Intent intent = new Intent(currentActivity, ConversationActivity.class);
+
+        if (userId != null) {
+
+            intent.putExtra(ConversationUIService.USER_ID, userId);
+            intent.putExtra(ConversationUIService.TAKE_ORDER, true);
+
+        }
+        if (userName != null && userName != "") {
+            intent.putExtra(ConversationUIService.DISPLAY_NAME, userName);
+        }
+        currentActivity.startActivity(intent);
+    }
+
+    @ReactMethod
     public void openChatWithGroup(Integer groupId, final Callback callback) {
 
         Activity currentActivity = getCurrentActivity();

--- a/ios/applozic/ApplozicChat.m
+++ b/ios/applozic/ApplozicChat.m
@@ -90,6 +90,21 @@ RCT_EXPORT_METHOD(openChatWithUser:(NSString*)userId)
   
 }
 /**
+ * Open chat with Users and display name
+ *
+ **/
+RCT_EXPORT_METHOD(openChatWithUserName:(NSString*)userId userName:(NSString*)userName)
+{
+  
+  ALChatManager * chatManager = [[ALChatManager alloc] init];
+  ALPushAssist* pushAssistant = [[ALPushAssist alloc] init];
+  
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [chatManager launchChatForUserWithDisplayName:userId withGroupId:nil andwithDisplayName:userName andFromViewController:pushAssistant.topViewController];
+  });
+  
+}
+/**
  * Open chat with Group
  *
  **/


### PR DESCRIPTION
We had been having issues with the display name of the users when we first open a chat with a user.
So we created a method were we can pass both the userId and a display name. It is also very handy when we don't want to show the actual user name.