### PR TITLE
Migrate android build to the new rn version

### DIFF
--- a/ApplozicSample/.babelrc
+++ b/ApplozicSample/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["react-native"]
+  "presets": ["react-native", "module:metro-react-native-babel-preset"]
 }

--- a/ApplozicSample/android/app/BUCK
+++ b/ApplozicSample/android/app/BUCK
@@ -45,12 +45,12 @@ android_library(
 
 android_build_config(
     name = "build_config",
-    package = "com.applozicsample",
+    package = "com.mobicomkit.sample",
 )
 
 android_resource(
     name = "res",
-    package = "com.applozicsample",
+    package = "com.mobicomkit.sample",
     res = "src/main/res",
 )
 

--- a/ApplozicSample/android/app/build.gradle
+++ b/ApplozicSample/android/app/build.gradle
@@ -73,7 +73,8 @@ import com.android.build.OutputFile
  */
 
 project.ext.react = [
-    entryFile: "index.js"
+    entryFile: "index.js",
+    enableHermes: false,  // clean and rebuild if changing
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"
@@ -92,6 +93,28 @@ def enableSeparateBuildPerCPUArchitecture = false
  * Run Proguard to shrink the Java bytecode in release builds.
  */
 def enableProguardInReleaseBuilds = false
+
+/**
+ * The preferred build flavor of JavaScriptCore.
+ *
+ * For example, to use the international variant, you can use:
+ * `def jscFlavor = 'org.webkit:android-jsc-intl:+'`
+ *
+ * The international variant includes ICU i18n library and necessary data
+ * allowing to use e.g. `Date.toLocaleString` and `String.localeCompare` that
+ * give correct results when using with locales other than en-US.  Note that
+ * this variant is about 6MiB larger per architecture than default.
+ */
+def jscFlavor = 'org.webkit:android-jsc:+'
+
+/**
+ * Whether to enable the Hermes VM.
+ *
+ * This should be set on project.ext.react and mirrored here.  If it is not set
+ * on project.ext.react, JavaScript will not be compiled to Hermes Bytecode
+ * and the benefits of using Hermes will therefore be sharply reduced.
+ */
+def enableHermes = project.ext.react.get("enableHermes", false);
 
 android {
     compileSdkVersion 28
@@ -134,14 +157,29 @@ android {
             }
         }
     }
+    packagingOptions {
+        pickFirst '**/armeabi-v7a/libc++_shared.so'
+        pickFirst '**/x86/libc++_shared.so'
+        pickFirst '**/arm64-v8a/libc++_shared.so'
+        pickFirst '**/x86_64/libc++_shared.so'
+        pickFirst '**/x86/libjsc.so'
+        pickFirst '**/armeabi-v7a/libjsc.so'
+    }
 }
 
 dependencies {
-    compile fileTree(dir: "libs", include: ["*.jar"])
-    compile "com.android.support:appcompat-v7:27.1.1"
-    compile project(':react-native-applozic-chat')
-    compile "com.facebook.react:react-native:+"  // From node_modules
-    compile 'com.android.support:multidex:1.0.0'
+    implementation fileTree(dir: "libs", include: ["*.jar"])
+    implementation project(':react-native-applozic-chat')
+    implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation 'com.android.support:multidex:1.0.0'
+
+    if (enableHermes) {
+        def hermesPath = "../../node_modules/hermes-engine/android/";
+        debugImplementation files(hermesPath + "hermes-debug.aar")
+        releaseImplementation files(hermesPath + "hermes-release.aar")
+    } else {
+        implementation jscFlavor
+    }
 
     /*configurations.all {
         resolutionStrategy.eachDependency { DependencyResolveDetails details ->
@@ -169,3 +207,5 @@ task copyDownloadableDepsToLibs(type: Copy) {
 }
 
 apply plugin: 'com.google.gms.google-services'
+
+apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)

--- a/ApplozicSample/android/app/src/main/AndroidManifest.xml
+++ b/ApplozicSample/android/app/src/main/AndroidManifest.xml
@@ -14,7 +14,8 @@
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        android:usesCleartextTraffic="true">
         <activity
             android:name=".MainActivity"
             android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
@@ -39,6 +40,8 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="com.mobicomkit.sample.MainActivity" />
         </activity>
+
+        <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
 
         <meta-data
             android:name="com.applozic.application.key"

--- a/ApplozicSample/android/app/src/main/java/com/mobicomkit/sample/MainApplication.java
+++ b/ApplozicSample/android/app/src/main/java/com/mobicomkit/sample/MainApplication.java
@@ -1,47 +1,50 @@
 package com.mobicomkit.sample;
 
 import android.app.Application;
-
+import android.content.Context;
+import com.facebook.react.PackageList;
 import com.facebook.react.ReactApplication;
+import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
-import com.facebook.react.shell.MainReactPackage;
 import com.facebook.soloader.SoLoader;
-import com.reactlibrary.ApplozicChatPackage;
-
-import java.util.Arrays;
+import java.lang.reflect.InvocationTargetException;
 import java.util.List;
+
+import com.reactlibrary.ApplozicChatPackage;
 
 public class MainApplication extends Application implements ReactApplication {
 
-    private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
+  private final ReactNativeHost mReactNativeHost =
+      new ReactNativeHost(this) {
         @Override
         public boolean getUseDeveloperSupport() {
-            return true;
+          return BuildConfig.DEBUG;
         }
 
         @Override
         protected List<ReactPackage> getPackages() {
-            return Arrays.<ReactPackage>asList(
-                    new MainReactPackage(),
-                    new ApplozicChatPackage()
-            );
+          @SuppressWarnings("UnnecessaryLocalVariable")
+          List<ReactPackage> packages = new PackageList(this).getPackages();
+          // Packages that cannot be autolinked yet can be added manually here, for example:
+          packages.add(new ApplozicChatPackage());
+          return packages;
         }
 
         @Override
         protected String getJSMainModuleName() {
-            return "index";
+          return "index";
         }
-    };
+      };
 
-    @Override
-    public ReactNativeHost getReactNativeHost() {
-        return mReactNativeHost;
-    }
+  @Override
+  public ReactNativeHost getReactNativeHost() {
+    return mReactNativeHost;
+  }
 
-    @Override
-    public void onCreate() {
-        super.onCreate();
-        SoLoader.init(this, /* native exopackage */ false);
-    }
+  @Override
+  public void onCreate() {
+    super.onCreate();
+    SoLoader.init(this, /* native exopackage */ false);
+  }
 }

--- a/ApplozicSample/android/build.gradle
+++ b/ApplozicSample/android/build.gradle
@@ -29,6 +29,9 @@ allprojects {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"
         }
+        maven {
+            url("$rootDir/../node_modules/jsc-android/dist")
+        }
         jcenter()
         maven {
             url 'https://maven.google.com/'

--- a/ApplozicSample/android/settings.gradle
+++ b/ApplozicSample/android/settings.gradle
@@ -1,4 +1,6 @@
 rootProject.name = 'ApplozicSample'
+apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
+
 include ':react-native-applozic-chat'
 project(':react-native-applozic-chat').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-applozic-chat/android')
 

--- a/ApplozicSample/package.json
+++ b/ApplozicSample/package.json
@@ -7,14 +7,15 @@
     "test": "jest"
   },
   "dependencies": {
-    "react": "16.2.0",
+    "react": "^16.4.0",
     "react-native": "0.61.2",
     "react-native-applozic-chat": "file:.."
   },
   "devDependencies": {
     "babel-jest": "22.1.0",
-    "babel-preset-react-native": "4.0.0",
+    "babel-preset-react-native": "^5.0.2",
     "jest": "22.1.1",
+    "metro-react-native-babel-preset": "^0.61.0",
     "react-test-renderer": "16.2.0"
   },
   "jest": {

--- a/ApplozicSample/react-native.config.js
+++ b/ApplozicSample/react-native.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  dependencies: {
+    'react-native-applozic-chat': { 
+      platforms: {
+        android: undefined,
+        ios: undefined,
+      }
+    }
+  }
+};


### PR DESCRIPTION
The project was not building because the react native was `0.61.2`, but the build files were belonging to `0.59.x` version.

So i did some improvements on the android build files to make this compatible with the choose react-native version.

Now it's working good.